### PR TITLE
Fix: Install dependencies in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - nightly
   - hhvm
 
-before_script:
+install:
   composer --dev install
 
 script:
@@ -15,7 +15,7 @@ script:
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-  
+
 matrix:
   allow_failures:
     - php: nightly


### PR DESCRIPTION
This PR

* [x] moves installation of dependencies with Composer from the `before_script` section to the `install` section